### PR TITLE
Make task-master process one document at a time.

### DIFF
--- a/apps/task-master/src/main.ts
+++ b/apps/task-master/src/main.ts
@@ -22,9 +22,9 @@ async function main() {
   const channel = await getAMQPChannel(amqpServerUrl);
   await channel.assertQueue(queueName);
 
-  // This consumes all messages at once in parallel. This can overwhelm the LLM.
-  // TODO: Optimize this so it only consumes max N messages at a time. We may need to do
-  // prefetch with ack: https://amqp-node.github.io/amqplib/channel_api.html#channel_prefetch
+  // We are consuming one message at a time for now.
+  channel.prefetch(1);
+
   channel.consume(
     queueName,
     async (data) => {
@@ -35,9 +35,10 @@ async function main() {
         for await (const chunk of asyncGenerator) {
           logger.info(`[doc = ${msg.documentId}] chunk`, chunk);
         }
+        channel.ack(data)
       }
     },
-    { noAck: true }
+    { noAck: false }
   );
 }
 


### PR DESCRIPTION
1. set noAck to false. This is because we need the unprocessed messages to go back to the queue. We explicitly ack the message once the message is processed. Current timeout for ack is 30 mins by default. For now, it should be fine because we expect the message to get processed within 30 mins. If it goes over it, task master will stop.
2. consume one message at a time. In future, we should play around with this config when we add more consumers 