### PR TITLE
RabbitMQ startup failed Fix

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -104,7 +104,7 @@ services:
   message-broker:
     image: rabbitmq:management
     volumes:
-      - ./message-broker:/var/lib/rabbitmq
+      - ./message-broker:/var/lib/rabbitmq/mnesia
     environment:
       - RABBITMQ_DEFAULT_USER=${RABBITMQ_DEFAULT_USER}
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}


### PR DESCRIPTION
When running the docker compose in WSL Ubuntu, RabbitMQ Containers failed to run, stating "Cookie file /var/lib/rabbitmq/.erlang.cookie must be accessible by owner only" Error. It is fixed by changing the RabbitMQ volume to ./message-broker:/var/lib/rabbitmq/mnesia