### PR TITLE
Moving the embeddings model to the env file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ SecureAI Tools can be used with OpenAI APIs and any other provider that provides
 
    ```.env
    # For OpenAI
-   MODEL_PROVIDER_CONFIGS='[{"type":"OPENAI","apiBaseUrl":"https://api.openai.com/v1","apiKey":"sk-..."}]'
+   MODEL_PROVIDER_CONFIGS='[{"type":"OPENAI","apiBaseUrl":"https://api.openai.com/v1","apiKey":"sk-...","embeddingsModel":"text-embedding-3-large"}]'
 
    # For OpenAI-compatible other provider
-   MODEL_PROVIDER_CONFIGS='[{"type":"OPENAI","apiBaseUrl":"...URL of API provider here ...","apiKey":"sk-..."}]'
+   MODEL_PROVIDER_CONFIGS='[{"type":"OPENAI","apiBaseUrl":"...URL of API provider here ...","apiKey":"sk-...","embeddingsModel":"text-embedding-3-large"}]'
    ```
 
-2. Go to the organization settings page, select OpenAI model type, and provide the appropriate model name like `gpt3.5-turbo`
+2. Go to the organization settings page, select OpenAI model type, and provide the appropriate model name like `gpt-4o`
 
 ### Customize LLM provider-specific options
 

--- a/apps/task-master/.env.example
+++ b/apps/task-master/.env.example
@@ -16,14 +16,14 @@ INFERENCE_SERVER="http://localhost:28664/"
 VECTOR_DB_SERVER="http://localhost:8000"
 
 # Document indexing and retrieval configs
-DOCS_INDEXING_CHUNK_SIZE=1000
+DOCS_INDEXING_CHUNK_SIZE=2800
 DOCS_INDEXING_CHUNK_OVERLAP=200
 DOCS_RETRIEVAL_K=2
 
 # Model provider configs
 # Configure external model providers here. Needs to be serialized JSON of ModelProviderConfig[]
 # https://github.com/SecureAI-Tools/SecureAI-Tools/blob/main/packages/core/src/types/model-provider-config.ts
-MODEL_PROVIDER_CONFIGS='[{"type":"OPENAI","apiBaseUrl":"https://api.openai.com/v1","apiKey":"..."}]'
+MODEL_PROVIDER_CONFIGS='[{"type":"OPENAI","apiBaseUrl":"https://api.openai.com/v1","apiKey":"...","embeddingsModel":"text-embedding-3-large"}]'
 
 # AMQP Server (RabbitMQ) info
 AMQP_SERVER_URL="amqp://localhost:5672"

--- a/apps/task-master/.env.example
+++ b/apps/task-master/.env.example
@@ -16,7 +16,8 @@ INFERENCE_SERVER="http://localhost:28664/"
 VECTOR_DB_SERVER="http://localhost:8000"
 
 # Document indexing and retrieval configs
-DOCS_INDEXING_CHUNK_SIZE=2800
+# Please check your embeddings model limits and increase it if it's allowed, for OpenAI text-embedding-3-large model, the limit is 3000 tokens so this could be set up to 2800
+DOCS_INDEXING_CHUNK_SIZE=1000
 DOCS_INDEXING_CHUNK_OVERLAP=200
 DOCS_RETRIEVAL_K=2
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -34,14 +34,14 @@ INFERENCE_SERVER="http://localhost:28664/"
 VECTOR_DB_SERVER="http://localhost:8000"
 
 # Document indexing and retrieval configs
-DOCS_INDEXING_CHUNK_SIZE=1000
+DOCS_INDEXING_CHUNK_SIZE=2800
 DOCS_INDEXING_CHUNK_OVERLAP=200
 DOCS_RETRIEVAL_K=2
 
 # Model provider configs
 # Configure external model providers here. Needs to be serialized JSON of ModelProviderConfig[]
 # https://github.com/SecureAI-Tools/SecureAI-Tools/blob/main/packages/core/src/types/model-provider-config.ts
-# MODEL_PROVIDER_CONFIGS='[{"type":"OPENAI","apiBaseUrl":"https://api.openai.com/v1","apiKey":"..."}]'
+# MODEL_PROVIDER_CONFIGS='[{"type":"OPENAI","apiBaseUrl":"https://api.openai.com/v1","apiKey":"...","embeddingsModel":"text-embedding-3-large"}]'
 
 # OAuth configs for data sources (except for GOOGLE_DRIVE -- it is configured at organization level).
 # Serialized JSON of DataSourceOAuthConfig[]

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -34,7 +34,8 @@ INFERENCE_SERVER="http://localhost:28664/"
 VECTOR_DB_SERVER="http://localhost:8000"
 
 # Document indexing and retrieval configs
-DOCS_INDEXING_CHUNK_SIZE=2800
+# Please check your embeddings model limits and increase it if it's allowed, for OpenAI text-embedding-3-large model, the limit is 3000 tokens so this could be set up to 2800
+DOCS_INDEXING_CHUNK_SIZE=1000
 DOCS_INDEXING_CHUNK_OVERLAP=200
 DOCS_RETRIEVAL_K=2
 

--- a/deployment/example.env
+++ b/deployment/example.env
@@ -32,7 +32,8 @@ NEXTAUTH_URL="http://localhost:28669/"
 LOG_LEVEL="info"
 
 # Document indexing and retrieval configs
-DOCS_INDEXING_CHUNK_SIZE=2800
+# Please check your embeddings model limits and increase it if it's allowed, for OpenAI text-embedding-3-large model, the limit is 3000 tokens so this could be set up to 2800
+DOCS_INDEXING_CHUNK_SIZE=1000
 DOCS_INDEXING_CHUNK_OVERLAP=200
 DOCS_RETRIEVAL_K=2
 

--- a/deployment/example.env
+++ b/deployment/example.env
@@ -32,14 +32,14 @@ NEXTAUTH_URL="http://localhost:28669/"
 LOG_LEVEL="info"
 
 # Document indexing and retrieval configs
-DOCS_INDEXING_CHUNK_SIZE=1000
+DOCS_INDEXING_CHUNK_SIZE=2800
 DOCS_INDEXING_CHUNK_OVERLAP=200
 DOCS_RETRIEVAL_K=2
 
 # Model provider configs
 # Configure external model providers here. Needs to be serialized JSON of ModelProviderConfig[]
 # https://github.com/SecureAI-Tools/SecureAI-Tools/blob/main/packages/core/src/types/model-provider-config.ts
-# MODEL_PROVIDER_CONFIGS='[{"type":"OPENAI","apiBaseUrl":"https://api.openai.com/v1","apiKey":"..."}]'
+# MODEL_PROVIDER_CONFIGS='[{"type":"OPENAI","apiBaseUrl":"https://api.openai.com/v1","apiKey":"...","embeddingsModel":"text-embedding-3-large"}]'
 
 # OAuth configs for data sources (except for GOOGLE_DRIVE -- it is configured at organization level).
 # Serialized JSON of DataSourceOAuthConfig[]

--- a/packages/backend/src/services/model-provider-service.ts
+++ b/packages/backend/src/services/model-provider-service.ts
@@ -94,9 +94,7 @@ export class ModelProviderService {
           // Unlike Ollama, OpenAI has different model names for embedding v/s completion.
           // It does not allow completion models for embedding APIs.
           // https://platform.openai.com/docs/guides/embeddings/what-are-embeddings
-          //
-          // TODO: Make this part of MODEL_PROVIDER_CONFIGS if/when needed!
-          modelName: "text-embedding-ada-002",
+          modelName: config.embeddingsModel || "text-embedding-ada-002",
           configuration: {
             baseURL: config.apiBaseUrl,
           },

--- a/packages/core/src/types/model-provider-config.ts
+++ b/packages/core/src/types/model-provider-config.ts
@@ -4,6 +4,7 @@ export interface ModelProviderConfig {
   type: ModelType;
   apiBaseUrl: string;
   apiKey?: string;
+  embeddingsModel?: string;
 
   // If specified => system will restrict users to those model strings
   // If not specified or empty => system will allow any arbitrary model name

--- a/packages/core/src/types/model-provider-config.ts
+++ b/packages/core/src/types/model-provider-config.ts
@@ -4,6 +4,7 @@ export interface ModelProviderConfig {
   type: ModelType;
   apiBaseUrl: string;
   apiKey?: string;
+  // Model to compute the embeddings. Supported for OpenAI only for now
   embeddingsModel?: string;
 
   // If specified => system will restrict users to those model strings


### PR DESCRIPTION
The aim of the PR is to support the newest model of of OpenAI ``text-embedding-3-large`` which support 3 times the dimensions as the old model, resulting in a much faster indexing time. 

I have changed the docs, model provider interface and the model provider service. 
I have added a fallback for the default old ``text-embedding-ada-002`` for backward compatability. 
I have changed the ``DOCS_INDEXING_CHUNK_SIZE`` to 2800 as thew new embeddings model support up to 3072 tokens while the old one supports 1536


